### PR TITLE
feat: parse one & parse grammar and guard

### DIFF
--- a/src/kind2.kind2
+++ b/src/kind2.kind2
@@ -376,6 +376,13 @@ Code : Type
 (Parser a:Type): Type
   (Parser a) = ∀(x: Code) (Answer a)
 
+// TODO: Improve later with string sugar
+TodoMsg.SyntaxError : String
+  TodoMsg.SyntaxError = (StrCons 83 (StrCons 121 (StrCons 110 (StrCons 116 (StrCons 97 (StrCons 120 (StrCons 32 (StrCons 69 (StrCons 114 (StrCons 114 (StrCons 111 (StrCons 114 StrNil))))))))))))
+  
+TodoMsg.TODO : String
+  TodoMsg.TODO = (StrCons 84 (StrCons 79 (StrCons 68 (StrCons 79 StrNil))))
+
 (Parser.is_name_char chr:Char) : Char
   (Parser.is_name_char chr) = 
   // TODO: rewrite later using quoted strings
@@ -418,9 +425,6 @@ Code : Type
     (| (== 33  chr)
        0))))))))))))
 
-//Parser.bind : @ (a : Type) (b : Type) (a_parser : (Parser a)) (f : @ (x: a) -> (Parser b)) -> (Parser b)
-//Parser.bind     (a : Type) (b : Type) (a_parser : (Parser a)) (f : @ (x: a) -> (Parser b)) :  (Parser b)
-
 (Parser.bind a:Type b:Type a_parser:(Parser a) f:(∀(x:a)(Parser b))): (Parser b)
   (Parser.bind a b a_parser f) = λcode (Parser.bind.go a b f (a_parser code))
 
@@ -433,6 +437,13 @@ Code : Type
 
 (Char.is_space chr:Char) : U32
   (Char.is_space chr) = (| (== 10 chr) (== 32 chr))
+
+(Parser.parse_one) : (Parser U32)
+  (Parser.parse_one) = λcode (Parser.parse_one.go code)
+
+(Parser.parse_one.go code:String) : (Answer U32)
+  (Parser.parse_one.go (StrCons x xs)) = (Answer.parsed U32 xs x)
+  (Parser.parse_one.go StrNil)         = (Answer.parsed U32 StrNil 0)
 
 (Parser.get_name) : ∀(code: Code)(Pair String String)
   (Parser.get_name) = λcode (Parser.get_name.go code)
@@ -479,22 +490,18 @@ Code : Type
 (Parser.match_text text:String) : (Parser Bool)
   (Parser.match_text text) = λcode ((Parser.matcher Bool.true (Parser.text_comparer text)) (Parser.skipper code))
 
-//(Parser.bind.go a:Type b:Type f:(∀(x:a)(Parser b)) a_res:(Answer a)) : (Answer b)
-
 (Parser.parse_text_here text:String) : (Parser Unit)
-  //(Parser.parse_text_here text)      = (Parser.bind (Parser.match_text_here text) λgot(Parser.text_here_got got))
-  (Parser.parse_text_here text) =
-    (Parser.bind Bool Unit (Parser.match_text_here text) λgot(Parser.text_here_got got))
+  (Parser.parse_text_here text) = (Parser.bind Bool Unit (Parser.match_text_here text) λgot(Parser.text_here_got got))
+  (Parser.parse_text_here text) = (Parser.bind Bool Unit (Parser.match_text_here text) λgot(Parser.text_here_got got))
 
 (Parser.text_here_got got:Bool) : (Parser Unit)
-  //(Parser.text_here_got (Bool.false)) = λcode (Answer.failed Unit "Syntax error.") // TODO: requires string syntax sugar
+  (Parser.text_here_got (Bool.false)) = λcode (Answer.failed Unit TodoMsg.SyntaxError) 
   (Parser.text_here_got (Bool.true))  = (Parser.done Unit Unit.new)
 
 (Parser.parse_text text:String) : (Parser Unit)
   (Parser.parse_text text) = λcode ((Parser.parse_text_here text) (Parser.skipper code))
 
 // Skips spaces and comments
-
 (Parser.skipper str:String) : String
   (Parser.skipper StrNil)         = StrNil
   (Parser.skipper (StrCons x xs)) = (Parser.skipper.go (Char.is_space x) (== x 47) x xs)
@@ -539,26 +546,20 @@ Code : Type
   (Parser.parse_until.go a Bool.true stop parser) =
     (Parser.done (List a) (List.nil a))
 
-//(ErrorMsg.TODO) : String
-  //(ErrorMsg.TODO) = (StrCons 84 (StrCons 79 (StrCons 68 (StrCons 79 StrNil))))
+(Parser.grammar a:Type choices:(List (Parser (Maybe a))))          : (Parser a)
+  (Parser.grammar a (List.nil (Parser (Maybe a))))                 = λcode (Answer.failed a TodoMsg.TODO)
+  (Parser.grammar a (List.cons (Parser (Maybe a)) choice choices)) = λcode (Parser.grammar.go a (choice code) choices)
 
-// // TODO: Finish this
-//(Parser.grammar a:Type choices:(List (Parser (Maybe a))))          : (Parser a)
-  //(Parser.grammar a (List.nil (Parser (Maybe a))))                 = λcode (Answer.failed a ErrorMsg.TODO)
-  //(Parser.grammar a (List.cons (Parser (Maybe a)) choice choices)) = λcode (Parser.grammar.go a (choice code) choices)
+(Parser.grammar.go a:Type choice_res:(Answer (Maybe a)) choices:(List (Parser (Maybe a)))) : (Answer a)
+  (Parser.grammar.go a (Answer.failed a err)                        choices) = (Answer.failed a err)
+  (Parser.grammar.go a (Answer.parsed a code (Maybe.none a))        choices) = ((Parser.grammar a choices) code)
+  (Parser.grammar.go a (Answer.parsed a code (Maybe.some a result)) choices) = (Answer.parsed a code result)
 
-//// (Parser.grammar.go a:Type choice_res:(Answer a) choices:(List (Parser (Maybe a)))) : (Answer a)
-////   (Parser.grammar.go a (Answer.failed a err)                        choices) = (Answer.failed a err)
-////   (Parser.grammar.go a (Answer.parsed a code (Maybe.none a))        choices) = ((Parser.grammar a choices) code)
-////   (Parser.grammar.go a (Answer.parsed a code (Maybe.some a result)) choices) = (Answer.parsed a code result)
+// Note: unlike Rust's version, this won't rollback
+(Parser.guard a:Type head:(Parser Bool) body:(Parser a)) : (Parser (Maybe a))
+  (Parser.guard a head body) = λcode (Parser.guard.go a (head code) body)
 
-//// Note: unlike Rust's version, this won't rollback
-//(Parser.guard a:Type head:(Parser Bool) body:(Parser a)) : (Parser (Maybe a))
-  //(Parser.guard a head body) = λcode (Parser.guard.go a (head code) body)
-
-  //// TODO: Finish this
-//(Parser.guard.go a:Type head_res:(Answer Bool) body:(Parser a)) : (Answer (Maybe a))
-  //(Parser.guard.go a (Answer.failed Bool err)             body) = (Answer.failed (Maybe a) err)
-  //(Parser.guard.go a (Answer.parsed Bool code Bool.false) body) = (Answer.parsed (Maybe a) code (Maybe.none a))
-  //// (Parser.guard.go a (Answer.parsed Bool code Bool.true)  body) = ((Parser.bind _ body λgot (Parser.done _ (Maybe.some a got))) code)
-
+(Parser.guard.go a:Type head_res:(Answer Bool) body:(Parser a)) : (Answer (Maybe a))
+  (Parser.guard.go a (Answer.failed Bool err)             body) = (Answer.failed (Maybe a) err)
+  (Parser.guard.go a (Answer.parsed Bool code Bool.false) body) = (Answer.parsed (Maybe a) code (Maybe.none a))
+  (Parser.guard.go a (Answer.parsed Bool code Bool.true)  body) = ((Parser.bind a (Maybe a) body λgot (Parser.done _ (Maybe.some a got))) code)


### PR DESCRIPTION
I've done the `Parser.guard`, `Parser.grammar` and I did the `Parser.parse_one` that you did yesterday in the `kind2.hvm`.

I did some tests with the Kind2 string sugar, but I was getting a type error, so I added the `TodoMsg.some_cute_msg` to replace the texts for now. Later on we just can just quote the `some_cute_msg` and we'll be good to go.